### PR TITLE
extract notes from deprecate annotation

### DIFF
--- a/opt2doc/src/lib.rs
+++ b/opt2doc/src/lib.rs
@@ -14,8 +14,7 @@ pub struct FieldMetadata {
     pub doc: Option<String>,
     pub ty: Vec<String>,
     pub default: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deprecated: Option<bool>,
+    pub deprecated: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -175,7 +174,7 @@ pub fn compsite_to_markdown(compsite: &CompsiteMetadata) -> String {
             field.ty.join("."),
             field.default.unwrap_or("--".to_string()),
             field.doc.unwrap_or("--".to_string()),
-            field.deprecated.unwrap_or(false)
+            field.deprecated.unwrap_or("--".to_string())
         ));
     }
     output

--- a/test_derive/src/main.rs
+++ b/test_derive/src/main.rs
@@ -15,10 +15,21 @@ pub struct Opt {
     #[opt2doc(rename = "cfg_name", default = "UTC", typ = "String")]
     id: usize,
     inner: InnerOpt,
+    deprecated: Deprecated,
 }
 
 #[derive(Debug, Opt2Doc)]
 pub struct InnerOpt {
     cfg: bool,
     ttl: usize,
+}
+
+#[derive(Debug, Opt2Doc)]
+pub struct Deprecated {
+    #[deprecated]
+    plain: String,
+    #[deprecated = "some deprecate message"]
+    with_message: String,
+    #[deprecated(since = "v0.1.1", note = "another deprecate message")]
+    since_and_note: String,
 }


### PR DESCRIPTION
Follow-up of #1 

Example:
```rust
#[derive(Debug, Opt2Doc)]
pub struct Deprecated {
    #[deprecated]
    plain: String,
    #[deprecated = "some deprecate message"]
    with_message: String,
    #[deprecated(since = "v0.1.1", note = "another deprecate message")]
    since_and_note: String,
}
```
gets to
```json
{
    "name": "Deprecated",
    "doc": "",
    "fields": [
        [
            "plain",
            {
                "name": "plain",
                "doc": "",
                "ty": [
                    "String"
                ],
                "default": null,
                "deprecated": "true"
            }
        ],
        [
            "with_message",
            {
                "name": "with_message",
                "doc": "",
                "ty": [
                    "String"
                ],
                "default": null,
                "deprecated": "some deprecate message"
            }
        ],
        [
            "since_and_note",
            {
                "name": "since_and_note",
                "doc": "",
                "ty": [
                    "String"
                ],
                "default": null,
                "deprecated": "since: v0.1.1, note: another deprecate message"
            }
        ]
    ]
}
```